### PR TITLE
Fix a bug with disabled annotation type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.antkorwin</groupId>
     <artifactId>better-strings</artifactId>
     <packaging>jar</packaging>
-    <version>0.1</version>
+    <version>0.2</version>
 
     <!-- region Info -->
     <name>BetterStrings Java Plugin</name>

--- a/src/main/java/com/antkorwin/betterstrings/BetterStringsProcessor.java
+++ b/src/main/java/com/antkorwin/betterstrings/BetterStringsProcessor.java
@@ -22,7 +22,7 @@ import com.sun.tools.javac.util.Context;
 /**
  * Created on 2019-09-02
  * <p>
- * TODO: replace on the JavaDoc
+ * String interpolation annotation processor
  *
  * @author Korovin Anatoliy
  */

--- a/src/main/java/com/antkorwin/betterstrings/ast/InnerStringVarsAstTranslator.java
+++ b/src/main/java/com/antkorwin/betterstrings/ast/InnerStringVarsAstTranslator.java
@@ -71,7 +71,7 @@ public class InnerStringVarsAstTranslator extends TreeTranslator {
 	private boolean isAnnotatedBySkip(JCTree.JCModifiers modifiers) {
 
 		for (JCTree.JCAnnotation annotation : modifiers.getAnnotations()) {
-			if (annotation.getAnnotationType() == null) {
+			if (annotation.getAnnotationType() == null || annotation.type == null) {
 				continue;
 			}
 			if (annotation.type.toString().equals(DisabledStringInterpolation.class.getCanonicalName())) {

--- a/src/main/java/com/antkorwin/betterstrings/ast/InnerStringVarsAstTranslator.java
+++ b/src/main/java/com/antkorwin/betterstrings/ast/InnerStringVarsAstTranslator.java
@@ -15,7 +15,8 @@ import com.sun.tools.javac.util.Names;
 /**
  * Created on 2019-09-10
  * <p>
- * TODO: replace on the JavaDoc
+ * AST translator to change the code of String literals
+ * on the code of java expressions.
  *
  * @author Korovin Anatoliy
  */

--- a/src/main/java/com/antkorwin/betterstrings/ast/InnerStringVarsAstTranslator.java
+++ b/src/main/java/com/antkorwin/betterstrings/ast/InnerStringVarsAstTranslator.java
@@ -73,7 +73,7 @@ public class InnerStringVarsAstTranslator extends TreeTranslator {
 			if (annotation.getAnnotationType() == null) {
 				continue;
 			}
-			if (annotation.getAnnotationType().toString().equals(DisabledStringInterpolation.class.getCanonicalName())) {
+			if (annotation.type.toString().equals(DisabledStringInterpolation.class.getCanonicalName())) {
 				return true;
 			}
 		}

--- a/src/main/java/com/antkorwin/betterstrings/tokenizer/Token.java
+++ b/src/main/java/com/antkorwin/betterstrings/tokenizer/Token.java
@@ -2,8 +2,9 @@ package com.antkorwin.betterstrings.tokenizer;
 
 /**
  * Created on 2019-09-11
- * <p>
- * TODO: replace on the JavaDoc
+ *
+ * internal type which used to split string
+ * literal with expressions on the list of tokens.
  *
  * @author Korovin Anatoliy
  */

--- a/src/test/java/com/antkorwin/betterstrings/BetterStringsProcessorTest.java
+++ b/src/test/java/com/antkorwin/betterstrings/BetterStringsProcessorTest.java
@@ -74,7 +74,6 @@ class BetterStringsProcessorTest {
 		assertThat(result).isEqualTo("password = 1234");
 	}
 
-
 	@Nested
 	class DisabledAnnotationTests {
 

--- a/src/test/java/com/antkorwin/betterstrings/BetterStringsProcessorTest.java
+++ b/src/test/java/com/antkorwin/betterstrings/BetterStringsProcessorTest.java
@@ -157,5 +157,30 @@ class BetterStringsProcessorTest {
 
 			assertThat(result).isEqualTo("sum = ${3+4}");
 		}
+
+		@Test
+		void importDisabledAnnotationAndCheckType() {
+			@Language("Java") String classCode = "import com.antkorwin.betterstrings.*;" +
+			                                     "" +
+			                                     "public class Test { " +
+			                                     "  public static String sum(){ " +
+			                                     "      return \"sum = ${new NestedClass().test()}\";" +
+			                                     "  } " +
+			                                     "  @DisabledStringInterpolation" +
+			                                     "  public static class NestedClass {" +
+			                                     "      public String test(){" +
+			                                     "          return \"${3+4}\";" +
+			                                     "      }" +
+			                                     "  }" +
+			                                     "}";
+
+			Object result = new CompileTest().classCode("Test", classCode)
+			                                 .processor(new BetterStringsProcessor())
+			                                 .compile()
+			                                 .loadClass("Test")
+			                                 .invokeStatic("sum");
+
+			assertThat(result).isEqualTo("sum = ${3+4}");
+		}
 	}
 }


### PR DESCRIPTION
Annotation without a fully qualified path in the place of usage will be processed by javac in another way(for example when you import a package of annotation in the class file). The type of annotation doesn't contain the full path to class. This PR fixes this bug with DisabledStringInterpolation processing.